### PR TITLE
Add written question type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Questioner Base
+
+Este proyecto es un quiz interactivo implementado con HTML, CSS y JavaScript puro. Permite practicar preguntas almacenadas en un archivo CSV y lleva un control de repeticiones para ayudar a la memorización.
+
+## Características principales
+
+- **Carga de preguntas desde CSV**: se usa la biblioteca [Papa Parse](https://www.papaparse.com/) para procesar archivos CSV con el formato descrito en `doc/prompt.md`.
+- **Soporte para selección única, múltiple o preguntas de escritura** según cómo se definan las respuestas en el CSV.
+- **Seguimiento de repeticiones**: cada pregunta puede repetirse varias veces hasta ser respondida correctamente las veces requeridas.
+- **Persistencia del progreso** mediante `localStorage` y la opción de guardar o cargar ficheros JSON.
+- **Configuración**: desde la interfaz se pueden definir las repeticiones iniciales y el aumento al fallar una pregunta.
+- **Interfaz adaptable** para escritorio y dispositivos móviles.
+
+## Uso rápido
+
+1. Clona el repositorio y abre `index.html` en un navegador web moderno.
+2. El quiz cargará por defecto el archivo `questions.csv` incluido en el repositorio.
+3. Utiliza los botones de la parte superior para:
+   - Guardar o cargar el progreso (archivo JSON).
+   - Cargar un CSV diferente con tus propias preguntas.
+   - Reiniciar el avance actual.
+   - Ajustar la configuración del quiz.
+
+Si se desea utilizar un CSV propio, consulta `doc/prompt.md` para conocer el formato exacto que debe tener cada fila.
+
+**Nota**: algunos navegadores pueden bloquear la lectura del CSV local si `index.html` se abre directamente desde el sistema de archivos. En tal caso, es conveniente servir los archivos desde un pequeño servidor web (por ejemplo `python -m http.server`).
+
+## Estructura del repositorio
+
+- `index.html` – vista principal del quiz.
+- `script.js` – lógica de funcionamiento y manejo de estado.
+- `styles.css` – estilos de la interfaz.
+- `questions.csv` – ejemplo de preguntas en formato CSV.
+- `doc/prompt.md` – documento extenso que explica cómo preparar el archivo CSV.
+
+La licencia del proyecto es MIT (ver `LICENSE`).
+

--- a/doc/prompt.md
+++ b/doc/prompt.md
@@ -97,6 +97,18 @@ El sistema determina el tipo de pregunta (selección única o múltiple) y cómo
     "El sol gira alrededor de la Tierra.",Falso,,,,Verdadero,,,"En el modelo heliocéntrico, la Tierra y otros planetas giran alrededor del Sol."
     ```
 
+**D. Pregunta de Respuesta Escrita**
+
+*   **Definición:** Se proporciona solamente `Opción correcta 1` y **no** se rellenan las columnas de opciones incorrectas.
+*   **Comportamiento:**
+    *   Se muestra un cuadro de texto donde el usuario escribe la respuesta y puede enviarla con el botón "Aceptar" o presionando **Enter**.
+    *   La respuesta introducida se compara con la correcta ignorando mayúsculas, comas y espacios laterales mediante una coincidencia difusa del 85%.
+    *   Después de enviar, se indica si la respuesta fue correcta o no y se muestra la explicación si existe.
+*   **Ejemplo CSV:**
+    ```csv
+    "¿Cuál es la capital de Francia?",París,,,,,,"París es la capital de Francia."
+    ```
+
 **Consideraciones Adicionales:**
 
 *   **Campos Vacíos:** Si un campo opcional (como `Opción Correcta 2`, `Opción Incorrecta 3`, `Explicación`, etc.) no se utiliza para una pregunta en particular, simplemente déjelo vacío (es decir, `,,` en el CSV). No escriba "null" o "vacío".

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,22 @@
+# Plan for implementing writing question
+
+1. Detect writing question when parsing CSV:
+   - If a row has exactly one `Opción correcta` and none of the `Opción Incorrecta` fields,
+     mark the question with `isWritten: true`.
+   - Keep existing properties for other question types.
+
+2. Update `displayQuestion` to show a different UI when `isWritten` is true:
+   - Show the question text followed by an input box and an "Aceptar" button.
+   - The input listens for the `Enter` key to submit.
+
+3. Implement `submitWrittenAnswer` and `showWrittenExplanation`:
+   - Compare the user's text with the correct answer using a fuzzy match
+     (Levenshtein ratio ≥ 0.85), ignoring case, commas and leading/trailing spaces.
+   - After evaluating, update stats and display whether the answer was correct,
+     the correct answer if needed, any explanation text and a "Siguiente" button.
+
+4. Add small CSS styles for the input element if necessary.
+
+5. Document the new question type in `doc/prompt.md`.
+
+6. Run `npm test` (expected to fail as there is no package.json).

--- a/script.js
+++ b/script.js
@@ -156,11 +156,13 @@ function parseCSV(data) {
             return;
         }
 
+        const isWritten = correctAnswers.length === 1 && incorrectAnswers.length === 0;
         questions.push({
             pregunta: pregunta,
             correctAnswers: correctAnswers,
             incorrectAnswers: incorrectAnswers,
-            explicacion: explicacion
+            explicacion: explicacion,
+            isWritten: isWritten
         });
     });
     totalQuestions = questions.length;
@@ -295,6 +297,11 @@ function displayQuestion(index) {
         return;
     }
 
+    if (question.isWritten) {
+        displayWrittenQuestion(index);
+        return;
+    }
+
     isMultiSelectMode = question.correctAnswers.length > 1;
 
     // Mostrar info de repeticiones
@@ -413,6 +420,138 @@ function checkSingleAnswer(selectedOption, questionIndex, optionDiv) {
 
     updateStats(questionIndex, isCorrect);
     showExplanationAndNext(questionIndex, isCorrect, [selectedOption]);
+}
+
+function displayWrittenQuestion(index) {
+    let question = questions[index];
+    let stats = questionStats[index];
+
+    quizDiv.innerHTML = '';
+    if (quizContainerDiv) {
+        quizContainerDiv.classList.remove('correct-answer-border', 'incorrect-answer-border');
+    }
+
+    let repsDiv = document.createElement('div');
+    repsDiv.className = 'reps-remaining';
+    repsDiv.textContent = `Repeticiones faltantes para esta pregunta: ${stats.repetitionsRemaining}`;
+    quizDiv.appendChild(repsDiv);
+
+    let remainingDiv = document.createElement('div');
+    remainingDiv.className = 'questions-remaining';
+    remainingDiv.textContent = `Total de repeticiones restantes: ${getTotalRepetitionsRemaining()}`;
+    quizDiv.appendChild(remainingDiv);
+
+    let questionElement = document.createElement('h2');
+    questionElement.textContent = question.pregunta;
+    quizDiv.appendChild(questionElement);
+
+    let input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'written-answer-input';
+    input.className = 'written-answer-input';
+    quizDiv.appendChild(input);
+
+    let actionContainer = document.createElement('div');
+    actionContainer.className = 'action-buttons-container';
+
+    let submitButton = document.createElement('button');
+    submitButton.id = 'submit-written-button';
+    submitButton.className = 'confirm-button';
+    let buttonText = document.createElement('span');
+    buttonText.className = 'button-text';
+    buttonText.textContent = 'Aceptar';
+    submitButton.appendChild(buttonText);
+    submitButton.addEventListener('click', () => submitWrittenAnswer(index));
+    actionContainer.appendChild(submitButton);
+
+    quizDiv.appendChild(actionContainer);
+
+    input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            submitButton.click();
+        }
+    });
+}
+
+function submitWrittenAnswer(questionIndex) {
+    let input = document.getElementById('written-answer-input');
+    let submitButton = document.getElementById('submit-written-button');
+    if (input) input.disabled = true;
+    if (submitButton) submitButton.disabled = true;
+    resetKeyListener();
+
+    let userAnswer = input ? input.value : '';
+    let question = questions[questionIndex];
+    let isCorrect = fuzzyCompare(userAnswer, question.correctAnswers[0]);
+
+    updateStats(questionIndex, isCorrect);
+    showWrittenExplanation(questionIndex, isCorrect, userAnswer);
+}
+
+function showWrittenExplanation(questionIndex, isCorrect, userAnswer) {
+    let question = questions[questionIndex];
+    quizDiv.innerHTML = '';
+
+    if (quizContainerDiv) {
+        quizContainerDiv.classList.remove('correct-answer-border', 'incorrect-answer-border');
+        quizContainerDiv.classList.add(isCorrect ? 'correct-answer-border' : 'incorrect-answer-border');
+    }
+
+    let questionElement = document.createElement('h2');
+    questionElement.textContent = question.pregunta;
+    quizDiv.appendChild(questionElement);
+
+    let yourAnswerDiv = document.createElement('div');
+    yourAnswerDiv.className = 'selected-answers-display';
+    let title = document.createElement('p');
+    title.textContent = 'Tu respuesta:';
+    yourAnswerDiv.appendChild(title);
+    let ans = document.createElement('div');
+    ans.className = 'selected-option-display';
+    ans.textContent = userAnswer || '(Sin respuesta)';
+    ans.classList.add(isCorrect ? 'correct-selection' : 'incorrect-selection');
+    yourAnswerDiv.appendChild(ans);
+    quizDiv.appendChild(yourAnswerDiv);
+
+    if (!isCorrect) {
+        let correctDiv = document.createElement('div');
+        correctDiv.className = 'missed-correct-answers-display';
+        let pt = document.createElement('p');
+        pt.textContent = 'Respuesta correcta:';
+        correctDiv.appendChild(pt);
+        let val = document.createElement('div');
+        val.className = 'unselected-correct-option';
+        val.textContent = question.correctAnswers[0];
+        correctDiv.appendChild(val);
+        quizDiv.appendChild(correctDiv);
+    }
+
+    if (question.explicacion && question.explicacion.trim() !== '') {
+        let contextDiv = document.createElement('div');
+        contextDiv.className = 'context-info';
+        contextDiv.textContent = question.explicacion;
+        quizDiv.appendChild(contextDiv);
+    }
+
+    let nextButton = document.createElement('button');
+    nextButton.id = 'next-button';
+    nextButton.className = 'next-button';
+    let spaceSpan = document.createElement('span');
+    spaceSpan.className = 'key-indicator space';
+    spaceSpan.textContent = '⎵';
+    let nextContent = document.createElement('span');
+    nextContent.className = 'button-text';
+    nextContent.textContent = 'Siguiente';
+    nextButton.appendChild(spaceSpan);
+    nextButton.appendChild(nextContent);
+    nextButton.addEventListener('click', () => {
+        saveState();
+        showNextQuestion();
+    });
+    quizDiv.appendChild(nextButton);
+
+    setupKeyListenerForNext();
 }
 
 function submitMultiAnswer(questionIndex) {
@@ -613,6 +752,10 @@ function disableOptionsAndActions() {
     document.querySelectorAll('.confirm-button, .skip-button').forEach(button => {
         button.disabled = true;
     });
+    let textInput = document.getElementById('written-answer-input');
+    let textButton = document.getElementById('submit-written-button');
+    if (textInput) textInput.disabled = true;
+    if (textButton) textButton.disabled = true;
     resetKeyListener();
 }
 
@@ -683,6 +826,43 @@ function shuffleArray(array) {
         array[randomIndex] = temporaryValue;
     }
     return array;
+}
+
+function normalizeAnswer(text) {
+    return text.toLowerCase().trim().replace(/,/g, '');
+}
+
+function levenshtein(a, b) {
+    const matrix = [];
+    for (let i = 0; i <= b.length; i++) {
+        matrix[i] = [i];
+    }
+    for (let j = 0; j <= a.length; j++) {
+        matrix[0][j] = j;
+    }
+    for (let i = 1; i <= b.length; i++) {
+        for (let j = 1; j <= a.length; j++) {
+            if (b.charAt(i - 1) === a.charAt(j - 1)) {
+                matrix[i][j] = matrix[i - 1][j - 1];
+            } else {
+                matrix[i][j] = Math.min(
+                    matrix[i - 1][j - 1] + 1,
+                    matrix[i][j - 1] + 1,
+                    matrix[i - 1][j] + 1
+                );
+            }
+        }
+    }
+    return matrix[b.length][a.length];
+}
+
+function fuzzyCompare(a, b) {
+    const normA = normalizeAnswer(a);
+    const normB = normalizeAnswer(b);
+    if (normA.length === 0 && normB.length === 0) return true;
+    const distance = levenshtein(normA, normB);
+    const similarity = 1 - distance / Math.max(normA.length, normB.length);
+    return similarity >= 0.85;
 }
 
 function showStatusMessage(message, type = "info", duration = 3000) {

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,15 @@ body {
     margin-bottom: 0.75rem;
 }
 
+.written-answer-input {
+    width: 100%;
+    padding: 0.6rem 0.8rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
 .option {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- outline approach in plan.md
- detect questions with only one correct answer and no wrong answers as written questions
- show input box and button to answer; Enter key submits
- compare typed answer with fuzzy matching (85%) ignoring commas and case
- document new written question format in prompt guide
- minor README update

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844a0c050b48328adb8c1b48b97d6cc