### PR TITLE
Add home screen with collections carousel

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,31 +12,83 @@
 </head>
 <body>
     <header class="main-header">
-        <button id="open-sidebar" class="sidebar-toggle" aria-label="Abrir menú">&#9776;</button>
+        <button id="open-sidebar" class="sidebar-toggle" aria-label="Abrir menú">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+              <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM40,72H216a8,8,0,0,0,0-16H40a8,8,0,0,0,0,16ZM216,184H40a8,8,0,0,0,0,16H216a8,8,0,0,0,0-16Z"></path>
+            </svg>
+        </button>
         <span id="collection-title">Colección</span>
     </header>
 
     <aside id="sidebar" class="sidebar">
-        <button id="close-sidebar" class="sidebar-toggle close-sidebar" aria-label="Cerrar menú">&#9776;</button>
+        <button id="close-sidebar" class="sidebar-toggle close-sidebar" aria-label="Cerrar menú">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+              <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM40,72H216a8,8,0,0,0,0-16H40a8,8,0,0,0,0,16ZM216,184H40a8,8,0,0,0,0,16H216a8,8,0,0,0,0-16Z"></path>
+            </svg>
+        </button>
         <div class="menu-section">
-            <a href="/" id="home-link">Inicio</a>
-            <button id="change-collection-button">Cambiar colección</button>
+            <a href="/home" id="home-link" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M224,115.55V208a16,16,0,0,1-16,16H168a16,16,0,0,1-16-16V168a8,8,0,0,0-8-8H112a8,8,0,0,0-8,8v40a16,16,0,0,1-16,16H48a16,16,0,0,1-16-16V115.55a16,16,0,0,1,5.17-11.78l80-75.48.11-.11a16,16,0,0,1,21.53,0,1.14,1.14,0,0,0,.11.11l80,75.48A16,16,0,0,1,224,115.55Z"></path>
+                </svg>
+                <span>Inicio</span>
+            </a>
+            <button id="change-collection-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M216,72H131.31L104,44.69A15.86,15.86,0,0,0,92.69,40H40A16,16,0,0,0,24,56V200.62A15.4,15.4,0,0,0,39.38,216H216.89A15.13,15.13,0,0,0,232,200.89V88A16,16,0,0,0,216,72ZM40,56H92.69l16,16H40ZM216,200H40V88H216Z"></path>
+                </svg>
+                <span>Cambiar colección</span>
+            </button>
         </div>
         <div class="menu-section">
-            <button id="save-progress">Guardar progreso</button>
-            <button id="load-progress">Cargar progreso</button>
+            <button id="save-progress" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M219.31,80,176,36.69A15.86,15.86,0,0,0,164.69,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V91.31A15.86,15.86,0,0,0,219.31,80ZM168,208H88V152h80Zm40,0H184V152a16,16,0,0,0-16-16H88a16,16,0,0,0-16,16v56H48V48H164.69L208,91.31ZM160,72a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h56A8,8,0,0,1,160,72Z"></path>
+                </svg>
+                <span>Guardar progreso</span>
+            </button>
+            <button id="load-progress" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M219.31,80,176,36.69A15.86,15.86,0,0,0,164.69,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V91.31A15.86,15.86,0,0,0,219.31,80ZM168,208H88V152h80Zm40,0H184V152a16,16,0,0,0-16-16H88a16,16,0,0,0-16,16v56H48V48H164.69L208,91.31ZM160,72a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h56A8,8,0,0,1,160,72Z"></path>
+                </svg>
+                <span>Cargar progreso</span>
+            </button>
             <input type="file" id="file-input" accept=".json" style="display:none">
 
-            <button id="load-csv-button">Cargar CSV</button>
+            <button id="load-csv-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34ZM160,51.31,188.69,80H160ZM200,216H56V40h88V88a8,8,0,0,0,8,8h48V216Z"></path>
+                </svg>
+                <span>Cargar CSV</span>
+            </button>
             <input type="file" id="csv-file-input" accept=".csv" style="display:none">
 
-            <button id="reset-progress-button">Reiniciar Progreso</button>
+            <button id="reset-progress-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L44.59,96H72a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V56a8,8,0,0,1,16,0V85.8L60.25,60A96,96,0,0,1,224,128Z"></path>
+                </svg>
+                <span>Reiniciar Progreso</span>
+            </button>
         </div>
         <div class="menu-section">
-            <button id="config-button">Configuración</button>
-            <button id="login-button">Iniciar sesión</button>
+            <button id="config-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"></path>
+                </svg>
+                <span>Configuración</span>
+            </button>
+            <button id="login-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"></path>
+                </svg>
+                <span>Iniciar sesión</span>
+            </button>
         </div>
     </aside>
+    <div id="home-container" class="home-container hidden">
+        <h1>¿Qué estudiaremos hoy?</h1>
+        <div id="home-carousel" class="home-carousel"></div>
+    </div>
     <div class="quiz-container">
         <div id="quiz"></div>
         <!-- Elemento para mostrar mensajes de estado (opcional) -->

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ Este proyecto es un quiz interactivo implementado con HTML, CSS y JavaScript pur
 - **Modo claro u oscuro** seleccionable desde la configuración.
 - **Texto de botones negro** para asegurar contraste en ambos temas.
 - **Banner de error en preguntas múltiples** que resalta aciertos parciales en amarillo.
+- **La materia se muestra junto al nombre de la colección** en el encabezado y al seleccionar una colección.
+- **Menú lateral rediseñado con iconos** para facilitar la navegación.
 
 ## Uso rápido
 
 1. Clona el repositorio y abre `index.html` en un navegador web moderno.
-2. El quiz cargará por defecto el archivo `questions.csv` incluido en el repositorio.
-3. Utiliza los botones de la parte superior para:
+2. Al iniciar se muestra una pantalla de inicio accesible también en `/home` con las colecciones disponibles.
+3. El quiz cargará por defecto el archivo `questions.csv` incluido en el repositorio.
+4. Utiliza los botones de la parte superior para:
    - Guardar o cargar el progreso (archivo JSON).
    - Cargar un CSV diferente con tus propias preguntas.
    - Reiniciar el avance actual.
@@ -32,7 +35,7 @@ Si se desea utilizar un CSV propio, consulta `doc/prompt.md` para conocer el for
 
 ## Estructura del repositorio
 
-- `index.html` – vista principal del quiz.
+- `index.html` – página principal que muestra el home y el quiz.
 - `script.js` – lógica de funcionamiento y manejo de estado.
 - `styles.css` – estilos de la interfaz.
 - `questions.csv` – ejemplo de preguntas en formato CSV.

--- a/index.html
+++ b/index.html
@@ -12,31 +12,83 @@
 </head>
 <body>
     <header class="main-header">
-        <button id="open-sidebar" class="sidebar-toggle" aria-label="Abrir menú">&#9776;</button>
+        <button id="open-sidebar" class="sidebar-toggle" aria-label="Abrir menú">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+              <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM40,72H216a8,8,0,0,0,0-16H40a8,8,0,0,0,0,16ZM216,184H40a8,8,0,0,0,0,16H216a8,8,0,0,0,0-16Z"></path>
+            </svg>
+        </button>
         <span id="collection-title">Colección</span>
     </header>
 
     <aside id="sidebar" class="sidebar">
-        <button id="close-sidebar" class="sidebar-toggle close-sidebar" aria-label="Cerrar menú">&#9776;</button>
+        <button id="close-sidebar" class="sidebar-toggle close-sidebar" aria-label="Cerrar menú">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+              <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM40,72H216a8,8,0,0,0,0-16H40a8,8,0,0,0,0,16ZM216,184H40a8,8,0,0,0,0,16H216a8,8,0,0,0,0-16Z"></path>
+            </svg>
+        </button>
         <div class="menu-section">
-            <a href="/" id="home-link">Inicio</a>
-            <button id="change-collection-button">Cambiar colección</button>
+            <a href="/home" id="home-link" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M224,115.55V208a16,16,0,0,1-16,16H168a16,16,0,0,1-16-16V168a8,8,0,0,0-8-8H112a8,8,0,0,0-8,8v40a16,16,0,0,1-16,16H48a16,16,0,0,1-16-16V115.55a16,16,0,0,1,5.17-11.78l80-75.48.11-.11a16,16,0,0,1,21.53,0,1.14,1.14,0,0,0,.11.11l80,75.48A16,16,0,0,1,224,115.55Z"></path>
+                </svg>
+                <span>Inicio</span>
+            </a>
+            <button id="change-collection-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M216,72H131.31L104,44.69A15.86,15.86,0,0,0,92.69,40H40A16,16,0,0,0,24,56V200.62A15.4,15.4,0,0,0,39.38,216H216.89A15.13,15.13,0,0,0,232,200.89V88A16,16,0,0,0,216,72ZM40,56H92.69l16,16H40ZM216,200H40V88H216Z"></path>
+                </svg>
+                <span>Cambiar colección</span>
+            </button>
         </div>
         <div class="menu-section">
-            <button id="save-progress">Guardar progreso</button>
-            <button id="load-progress">Cargar progreso</button>
+            <button id="save-progress" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M219.31,80,176,36.69A15.86,15.86,0,0,0,164.69,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V91.31A15.86,15.86,0,0,0,219.31,80ZM168,208H88V152h80Zm40,0H184V152a16,16,0,0,0-16-16H88a16,16,0,0,0-16,16v56H48V48H164.69L208,91.31ZM160,72a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h56A8,8,0,0,1,160,72Z"></path>
+                </svg>
+                <span>Guardar progreso</span>
+            </button>
+            <button id="load-progress" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M219.31,80,176,36.69A15.86,15.86,0,0,0,164.69,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V91.31A15.86,15.86,0,0,0,219.31,80ZM168,208H88V152h80Zm40,0H184V152a16,16,0,0,0-16-16H88a16,16,0,0,0-16,16v56H48V48H164.69L208,91.31ZM160,72a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h56A8,8,0,0,1,160,72Z"></path>
+                </svg>
+                <span>Cargar progreso</span>
+            </button>
             <input type="file" id="file-input" accept=".json" style="display:none">
 
-            <button id="load-csv-button">Cargar CSV</button>
+            <button id="load-csv-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34ZM160,51.31,188.69,80H160ZM200,216H56V40h88V88a8,8,0,0,0,8,8h48V216Z"></path>
+                </svg>
+                <span>Cargar CSV</span>
+            </button>
             <input type="file" id="csv-file-input" accept=".csv" style="display:none">
 
-            <button id="reset-progress-button">Reiniciar Progreso</button>
+            <button id="reset-progress-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L44.59,96H72a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V56a8,8,0,0,1,16,0V85.8L60.25,60A96,96,0,0,1,224,128Z"></path>
+                </svg>
+                <span>Reiniciar Progreso</span>
+            </button>
         </div>
         <div class="menu-section">
-            <button id="config-button">Configuración</button>
-            <button id="login-button">Iniciar sesión</button>
+            <button id="config-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"></path>
+                </svg>
+                <span>Configuración</span>
+            </button>
+            <button id="login-button" class="menu-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"></path>
+                </svg>
+                <span>Iniciar sesión</span>
+            </button>
         </div>
     </aside>
+    <div id="home-container" class="home-container hidden">
+        <h1>¿Qué estudiaremos hoy?</h1>
+        <div id="home-carousel" class="home-carousel"></div>
+    </div>
     <div class="quiz-container">
         <div id="quiz"></div>
         <!-- Elemento para mostrar mensajes de estado (opcional) -->

--- a/script.js
+++ b/script.js
@@ -38,6 +38,8 @@ let quizContainerDiv = null; // <-- NUEVO: Referencia al contenedor principal
 let timeProgressDiv = null;
 let timeBarDiv = null;
 let timeRemainingSpan = null;
+let homeContainer = null;
+let homeCarousel = null;
 let sidebar = null;
 let openSidebarButton = null;
 let closeSidebarButton = null;
@@ -73,6 +75,46 @@ function updateUrlForCollection(id, replace = false) {
     }
 }
 
+function isHomePath() {
+    const path = window.location.pathname.replace(/\/+$/, '');
+    return path === '' || path === '/home';
+}
+
+function showHome() {
+    homeContainer?.classList.remove('hidden');
+    quizContainerDiv?.classList.add('hidden');
+    timeProgressDiv?.classList.add('hidden');
+}
+
+function showQuiz() {
+    homeContainer?.classList.add('hidden');
+    quizContainerDiv?.classList.remove('hidden');
+    timeProgressDiv?.classList.remove('hidden');
+}
+
+function populateHomeCarousel() {
+    if (!homeCarousel) return;
+    homeCarousel.innerHTML = '';
+    availableCollections.forEach(col => {
+        const card = document.createElement('div');
+        card.className = 'collection-card';
+        card.innerHTML = `
+            <span class="collection-subject">${col.materia || ''}</span>
+            <h3>${col.nombre}</h3>
+            <p>${col.descripcion || ''}</p>
+        `;
+        card.addEventListener('click', () => {
+            showQuiz();
+            updateUrlForCollection(col.id);
+            collectionSelect.value = col.id;
+            localStorage.setItem(COLLECTION_STORAGE_KEY, col.id);
+            loadQuestionsFromCollection(col.id);
+            updateCollectionTitleById(col.id);
+        });
+        homeCarousel.appendChild(card);
+    });
+}
+
 // --- Inicialización ---
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -85,6 +127,8 @@ document.addEventListener('DOMContentLoaded', function() {
     timeProgressDiv = document.getElementById('time-progress');
     timeBarDiv = document.getElementById('time-bar');
     timeRemainingSpan = document.getElementById('time-remaining');
+    homeContainer = document.getElementById('home-container');
+    homeCarousel = document.getElementById('home-carousel');
     collectionSelect = document.getElementById('collection-select');
     changeCollectionButton = document.getElementById('change-collection-button');
     collectionModalOverlay = document.getElementById('collection-modal-overlay');
@@ -112,7 +156,7 @@ document.addEventListener('DOMContentLoaded', function() {
         !changeCollectionButton || !collectionModalOverlay || !collectionModal || !confirmCollectionButton ||
         !configButton || !configModalOverlay || !configModal || !configRepsOnErrorInput ||
         !configInitialRepsInput || !configThemeSelect || !saveConfigButton || !closeModalButton || !closeModalXButton ||
-        !sidebar || !openSidebarButton || !closeSidebarButton || !collectionTitleSpan) {
+        !sidebar || !openSidebarButton || !closeSidebarButton || !collectionTitleSpan || !homeContainer || !homeCarousel) {
         console.error("Error: No se encontraron elementos esenciales del DOM (quiz, status, inputs, o elementos del modal).");
         if(quizDiv) quizDiv.innerHTML = "<p class='error-message'>Error crítico: Faltan elementos HTML esenciales para el quiz o la configuración.</p>";
         return;
@@ -128,6 +172,13 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('beforeunload', saveState);
     document.addEventListener('visibilitychange', handleVisibilityChange);
     autosaveIntervalId = setInterval(saveState, 10000);
+    window.addEventListener('popstate', () => {
+        if (isHomePath()) {
+            showHome();
+        } else {
+            showQuiz();
+        }
+    });
 });
 
 function setupEventListeners() {
@@ -207,7 +258,7 @@ async function loadCollections() {
         availableCollections.forEach(c => {
             const opt = document.createElement('option');
             opt.value = c.id;
-            opt.textContent = c.nombre;
+            opt.textContent = c.materia ? `${c.materia} - ${c.nombre}` : c.nombre;
             collectionSelect.appendChild(opt);
         });
         customOption = document.createElement('option');
@@ -215,6 +266,13 @@ async function loadCollections() {
         customOption.textContent = 'Personalizado';
         customOption.disabled = true;
         collectionSelect.appendChild(customOption);
+
+        populateHomeCarousel();
+
+        if (isHomePath()) {
+            showHome();
+            return;
+        }
 
         const saved = localStorage.getItem(COLLECTION_STORAGE_KEY);
         const pathId = getCollectionIdFromPath();
@@ -339,7 +397,11 @@ function updateCollectionTitleById(id) {
         collectionTitleSpan.textContent = 'Personalizado';
     } else {
         const col = availableCollections.find(c => c.id === id);
-        collectionTitleSpan.textContent = col ? col.nombre : 'Colección';
+        if (col) {
+            collectionTitleSpan.innerHTML = `<span class="collection-subject-inline">${col.materia}</span> ${col.nombre}`;
+        } else {
+            collectionTitleSpan.textContent = 'Colección';
+        }
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,7 @@
     --status-error-bg: #f8d7da;
     --status-error-color: #721c24;
     --status-error-border: #f5c6cb;
+    --subject-color: #d63384;
     --modal-bg: #fff;
 }
 
@@ -81,6 +82,7 @@ body.dark-mode {
     --partial-selection-color: #fff2b3;
     --partial-selection-border: #b1922c;
     --modal-bg: #2a2a2a;
+    --subject-color: #e670a5;
 }
 
 html {
@@ -127,6 +129,7 @@ body {
     color: var(--text-color);
     font-size: 1.5rem;
     cursor: pointer;
+    padding: 0.5rem 1rem;
 }
 
 #collection-title {
@@ -141,11 +144,13 @@ body {
     height: 100%;
     background-color: #222;
     color: #fff;
-    padding-top: 1rem;
+    padding-top: 0;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 100;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 .sidebar.open {
@@ -165,7 +170,7 @@ body.sidebar-open {
 
 .sidebar .menu-section {
     border-bottom: 1px solid #444;
-    padding: 0.5rem 0;
+    padding: 0.75rem 0;
 }
 
 .sidebar .menu-section:last-child {
@@ -174,7 +179,9 @@ body.sidebar-open {
 
 .sidebar button,
 .sidebar a {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     width: 100%;
     background: none;
     border: none;
@@ -184,6 +191,12 @@ body.sidebar-open {
     font: inherit;
     cursor: pointer;
     text-decoration: none;
+}
+.sidebar button svg,
+.sidebar a svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
 }
 
 .sidebar button:hover,
@@ -195,6 +208,7 @@ body.sidebar-open {
     display: none;
     text-align: left;
     color: #fff;
+    align-self: flex-end;
 }
 
 body.sidebar-open .close-sidebar {
@@ -764,4 +778,48 @@ body.sidebar-open #open-sidebar {
     padding: 2px 6px;
     border-radius: 4px;
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+/* --- Estilos para la pantalla de inicio --- */
+.home-container {
+    width: 90%;
+    max-width: 1000px;
+    margin: 2rem auto;
+    text-align: center;
+}
+
+.home-carousel {
+    display: flex;
+    overflow-x: auto;
+    gap: 1rem;
+    padding: 1rem 0;
+}
+
+.collection-card {
+    flex: 0 0 auto;
+    background-color: var(--container-bg);
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    padding: 1rem;
+    width: 220px;
+    cursor: pointer;
+    border: 2px solid transparent;
+    transition: border-color 0.3s ease;
+}
+
+.collection-card:hover {
+    border-color: var(--option-selected-border);
+}
+
+.collection-subject {
+    font-weight: bold;
+    color: var(--subject-color);
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.collection-subject-inline {
+    font-weight: bold;
+    color: var(--subject-color);
+    margin-right: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add a home section that lists collections in a carousel
- style the home screen and collection cards
- populate the carousel from Supabase collections
- show home when visiting `/` or `/home`
- document new behaviour in README
- show each collection's subject next to its name in the header and combo box
- redesign the sidebar with icons and improved alignment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685064482c188328bc454ee01575a731